### PR TITLE
Add Daily Training Plan tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Daily Training Plan</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="greeting" class="greeting"></div>
+    <div class="container">
+        <aside id="yesterday" class="side yesterday"></aside>
+        <main id="today" class="main"></main>
+        <aside id="tomorrow" class="side tomorrow"></aside>
+    </div>
+    <div id="streak" class="streak"></div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,175 @@
+const trainingPlan = {
+  monday: [
+    "Run 5km",
+    ["Swim 20 laps", "Cycle 10km"],
+    "Stretch for 15min"
+  ],
+  tuesday: [
+    "Yoga session",
+    ["Read a fitness article", "Watch a workout video"],
+    "Meditate for 10min"
+  ],
+  wednesday: [
+    "HIIT workout",
+    ["Push-ups", "Sit-ups"],
+    "Drink 2L of water"
+  ],
+  thursday: [
+    "Pilates",
+    ["Jump rope", "Light jog"],
+    "Healthy meal prep"
+  ],
+  friday: [
+    "Strength training",
+    ["Bench press", "Deadlift"],
+    "Protein shake"
+  ],
+  saturday: [
+    "Outdoor activity",
+    ["Hiking", "Kayaking"],
+    "Rest and recover"
+  ],
+  sunday: [
+    "Light stretching",
+    ["Family walk", "Easy bike ride"],
+    "Plan next week"
+  ]
+};
+
+function dateStr(date) {
+  return date.toISOString().split('T')[0];
+}
+
+function getPlanForDate(date) {
+  const key = 'plan_' + dateStr(date);
+  let stored = localStorage.getItem(key);
+  if (stored) return JSON.parse(stored);
+
+  const dayName = date.toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
+  const dayPlan = trainingPlan[dayName] || [];
+  const objectives = dayPlan.map(item => {
+    if (Array.isArray(item)) {
+      return item[Math.floor(Math.random() * item.length)];
+    }
+    return item;
+  });
+  const plan = { objectives };
+  localStorage.setItem(key, JSON.stringify(plan));
+  return plan;
+}
+
+function getProgressForDate(date, count) {
+  const key = 'progress_' + dateStr(date);
+  let stored = localStorage.getItem(key);
+  if (stored) return JSON.parse(stored);
+  const arr = new Array(count).fill(false);
+  localStorage.setItem(key, JSON.stringify(arr));
+  return arr;
+}
+
+function saveProgress(date, arr) {
+  const key = 'progress_' + dateStr(date);
+  localStorage.setItem(key, JSON.stringify(arr));
+}
+
+function updateStreakIfNeeded() {
+  const today = new Date();
+  const yesterday = new Date(Date.now() - 864e5);
+  const yesterdayKey = 'progress_' + dateStr(yesterday);
+  const progress = JSON.parse(localStorage.getItem(yesterdayKey) || '[]');
+  let streak = parseInt(localStorage.getItem('streak')) || 0;
+  const last = localStorage.getItem('lastCompletionDate');
+
+  if (dateStr(yesterday) !== last) {
+    streak = 0;
+  }
+
+  if (progress.length && progress.every(v => v)) {
+    if (last === dateStr(yesterday)) {
+      // streak already counted
+    } else {
+      streak += 1;
+      localStorage.setItem('lastCompletionDate', dateStr(yesterday));
+    }
+  }
+
+  localStorage.setItem('streak', streak);
+  return streak;
+}
+
+function setup() {
+  let name = localStorage.getItem('userName');
+  if (!name) {
+    name = prompt('What is your name?');
+    if (name) localStorage.setItem('userName', name);
+  }
+  const greeting = document.getElementById('greeting');
+  if (name) {
+    greeting.textContent = `Welcome back, ${name}!`;
+  }
+
+  const today = new Date();
+  const planToday = getPlanForDate(today);
+  const progress = getProgressForDate(today, planToday.objectives.length);
+
+  const main = document.getElementById('today');
+  main.innerHTML = `<h2>${today.toLocaleDateString('en-US', { weekday: 'long' })}</h2>`;
+
+  planToday.objectives.forEach((obj, idx) => {
+    const label = document.createElement('label');
+    label.className = 'objective';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = progress[idx];
+    checkbox.addEventListener('change', () => {
+      progress[idx] = checkbox.checked;
+      saveProgress(today, progress);
+      checkCompletion();
+    });
+    label.appendChild(checkbox);
+    label.appendChild(document.createTextNode(obj));
+    const div = document.createElement('div');
+    div.appendChild(label);
+    main.appendChild(div);
+  });
+
+  const streakElem = document.getElementById('streak');
+  const streak = updateStreakIfNeeded();
+  streakElem.textContent = `Daily Streak: ${streak}`;
+
+  showSide('yesterday', new Date(Date.now() - 864e5));
+  prepareTomorrow();
+  showSide('tomorrow', new Date(Date.now() + 864e5));
+
+  function checkCompletion() {
+    if (progress.every(v => v)) {
+      let streak = parseInt(localStorage.getItem('streak')) || 0;
+      const last = localStorage.getItem('lastCompletionDate');
+      const todayStrValue = dateStr(today);
+      if (last !== todayStrValue) {
+        streak += 1;
+        localStorage.setItem('lastCompletionDate', todayStrValue);
+      }
+      localStorage.setItem('streak', streak);
+      streakElem.textContent = `Daily Streak: ${streak}`;
+    }
+  }
+}
+
+function showSide(elementId, date) {
+  const container = document.getElementById(elementId);
+  const plan = getPlanForDate(date);
+  container.innerHTML = `<h3>${date.toLocaleDateString('en-US', { weekday: 'long' })}</h3>`;
+  plan.objectives.forEach(obj => {
+    const p = document.createElement('p');
+    p.textContent = obj;
+    container.appendChild(p);
+  });
+}
+
+function prepareTomorrow() {
+  const tomorrow = new Date(Date.now() + 864e5);
+  getPlanForDate(tomorrow); // generate and store if not existing
+}
+
+document.addEventListener('DOMContentLoaded', setup);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,65 @@
+body {
+    font-family: Arial, sans-serif;
+    background: linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%);
+    min-height: 100vh;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    color: #333;
+    animation: fadeIn 1s ease-in-out;
+}
+
+.container {
+    display: flex;
+    width: 90%;
+    max-width: 900px;
+    margin-top: 20px;
+}
+
+.side {
+    flex: 1;
+    padding: 10px;
+    background: rgba(255, 255, 255, 0.5);
+    border-radius: 10px;
+    margin: 0 10px;
+    min-height: 200px;
+    animation: slideIn 1s ease-in-out;
+}
+
+.main {
+    flex: 2;
+    padding: 20px;
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 10px;
+    text-align: center;
+    animation: zoomIn 0.5s ease-in-out;
+}
+
+.greeting {
+    margin-top: 20px;
+    font-size: 1.5em;
+    font-weight: bold;
+}
+
+.streak {
+    margin-top: 20px;
+    font-size: 1.2em;
+    font-weight: bold;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes slideIn {
+    from { transform: translateY(-10px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+}
+
+@keyframes zoomIn {
+    from { transform: scale(0.9); opacity: 0; }
+    to { transform: scale(1); opacity: 1; }
+}


### PR DESCRIPTION
## Summary
- add webpage layout
- style tracker with gradient background and animations
- implement daily training logic with localStorage support

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6886591a5038832b8b49ffc219a9180f