### PR TITLE
Add alternating language study plan

### DIFF
--- a/friday.js
+++ b/friday.js
@@ -1,5 +1,3 @@
 export default [
-  "Strength training",
-  ["Bench press", "Deadlift"],
-  "Protein shake"
+  "Pimsleur lesson"
 ];

--- a/monday.js
+++ b/monday.js
@@ -1,5 +1,3 @@
 export default [
-  "Run 5km",
-  ["Swim 20 laps", "Cycle 10km"],
-  "Stretch for 15min"
+  "Pimsleur lesson"
 ];

--- a/saturday.js
+++ b/saturday.js
@@ -1,5 +1,3 @@
 export default [
-  "Outdoor activity",
-  ["Hiking", "Kayaking"],
-  "Rest and recover"
+  "Duolingo session"
 ];

--- a/sunday.js
+++ b/sunday.js
@@ -1,5 +1,3 @@
 export default [
-  "Light stretching",
-  ["Family walk", "Easy bike ride"],
-  "Plan next week"
+  "Rest day"
 ];

--- a/thursday.js
+++ b/thursday.js
@@ -1,5 +1,3 @@
 export default [
-  "Pilates",
-  ["Jump rope", "Light jog"],
-  "Healthy meal prep"
+  "Duolingo session"
 ];

--- a/tuesday.js
+++ b/tuesday.js
@@ -1,5 +1,3 @@
 export default [
-  "Yoga session",
-  ["Read a fitness article", "Watch a workout video"],
-  "Meditate for 10min"
+  "Duolingo session"
 ];

--- a/wednesday.js
+++ b/wednesday.js
@@ -1,5 +1,3 @@
 export default [
-  "HIIT workout",
-  ["Push-ups", "Sit-ups"],
-  "Drink 2L of water"
+  "Pimsleur lesson"
 ];


### PR DESCRIPTION
## Summary
- set daily tasks so the schedule alternates between Pimsleur and Duolingo
- set Sundays as a rest day

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68865c60b618832b865d58a5f089ac01