### PR TITLE
Add Monday Go schedule

### DIFF
--- a/monday.js
+++ b/monday.js
@@ -1,3 +1,6 @@
 export default [
+  "Tsumego warm-up (15-20 min): basic shapes",
+  "Read fundamentals chapter: opening principles or tesuji",
+  "Easy tesuji set (15 min): quantity over difficulty",
   "Pimsleur lesson"
 ];


### PR DESCRIPTION
## Summary
- expand Monday tasks with Go study plan

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68865d64f030832b8dd4ae7ea95e2097