### PR TITLE
Update daily training tasks

### DIFF
--- a/friday.js
+++ b/friday.js
@@ -2,5 +2,9 @@ export default [
   "Pimsleur lesson",
   "Tsumego (20m) - try intermediate tesuji puzzles",
   "Pro game review (45m) - focus on fights and defense",
-  "Own game review (15m) - apply pro ideas"
+  "Own game review (15m) - apply pro ideas",
+  "Read 1-dan challenge chapter",
+  "play piano",
+  "calisthenics workout",
+  "go for run"
 ];

--- a/friday.js
+++ b/friday.js
@@ -4,7 +4,9 @@ export default [
   "Pro game review (45m) - focus on fights and defense",
   "Own game review (15m) - apply pro ideas",
   "Read 1-dan challenge chapter",
-  "play piano",
-  "calisthenics workout",
-  "go for run"
+  [
+    "play piano",
+    "calisthenics workout",
+    "go for run"
+  ]
 ];

--- a/monday.js
+++ b/monday.js
@@ -2,5 +2,9 @@ export default [
   "Tsumego warm-up (15-20 min): basic shapes",
   "Read fundamentals chapter: opening principles or tesuji",
   "Easy tesuji set (15 min): quantity over difficulty",
-  "Pimsleur lesson"
+  "Pimsleur lesson",
+  "Read 1-dan challenge chapter",
+  "play piano",
+  "calisthenics workout",
+  "go for run"
 ];

--- a/monday.js
+++ b/monday.js
@@ -4,7 +4,9 @@ export default [
   "Easy tesuji set (15 min): quantity over difficulty",
   "Pimsleur lesson",
   "Read 1-dan challenge chapter",
-  "play piano",
-  "calisthenics workout",
-  "go for run"
+  [
+    "play piano",
+    "calisthenics workout",
+    "go for run"
+  ]
 ];

--- a/saturday.js
+++ b/saturday.js
@@ -2,5 +2,9 @@ export default [
   "Duolingo session",
   "15 min mixed tsumego practice",
   "Play two games (one ranked, one experimental)",
-  "Review both games and save notable SGFs"
+  "Review both games and save notable SGFs",
+  "Read 1-dan challenge chapter",
+  "play piano",
+  "calisthenics workout",
+  "go for run"
 ];

--- a/saturday.js
+++ b/saturday.js
@@ -4,7 +4,9 @@ export default [
   "Play two games (one ranked, one experimental)",
   "Review both games and save notable SGFs",
   "Read 1-dan challenge chapter",
-  "play piano",
-  "calisthenics workout",
-  "go for run"
+  [
+    "play piano",
+    "calisthenics workout",
+    "go for run"
+  ]
 ];

--- a/sunday.js
+++ b/sunday.js
@@ -1,3 +1,7 @@
 export default [
-  "Go to Gym"
+  "Go to Gym",
+  "Read 1-dan challenge chapter",
+  "play piano",
+  "calisthenics workout",
+  "go for run"
 ];

--- a/sunday.js
+++ b/sunday.js
@@ -1,7 +1,9 @@
 export default [
   "Go to Gym",
   "Read 1-dan challenge chapter",
-  "play piano",
-  "calisthenics workout",
-  "go for run"
+  [
+    "play piano",
+    "calisthenics workout",
+    "go for run"
+  ]
 ];

--- a/thursday.js
+++ b/thursday.js
@@ -1,5 +1,9 @@
 export default [
   "Tsumego drills (15m)",
   "Play 3-4 blitz games (1h)",
-  "Review key moments (30m)"
+  "Review key moments (30m)",
+  "Read 1-dan challenge chapter",
+  "play piano",
+  "calisthenics workout",
+  "go for run"
 ];

--- a/thursday.js
+++ b/thursday.js
@@ -3,7 +3,9 @@ export default [
   "Play 3-4 blitz games (1h)",
   "Review key moments (30m)",
   "Read 1-dan challenge chapter",
-  "play piano",
-  "calisthenics workout",
-  "go for run"
+  [
+    "play piano",
+    "calisthenics workout",
+    "go for run"
+  ]
 ];

--- a/tuesday.js
+++ b/tuesday.js
@@ -3,7 +3,9 @@ export default [
   "Online Game (60\u201375 min): slow time, play aggressively with good shape",
   "Post-Game Review (30 min): note mistakes and check openings",
   "Read 1-dan challenge chapter",
-  "play piano",
-  "calisthenics workout",
-  "go for run"
+  [
+    "play piano",
+    "calisthenics workout",
+    "go for run"
+  ]
 ];

--- a/tuesday.js
+++ b/tuesday.js
@@ -1,5 +1,9 @@
 export default [
   "Duolingo session",
   "Online Game (60\u201375 min): slow time, play aggressively with good shape",
-  "Post-Game Review (30 min): note mistakes and check openings"
+  "Post-Game Review (30 min): note mistakes and check openings",
+  "Read 1-dan challenge chapter",
+  "play piano",
+  "calisthenics workout",
+  "go for run"
 ];

--- a/wednesday.js
+++ b/wednesday.js
@@ -1,5 +1,9 @@
 export default [
   "Tsumego: medium life & death set",
   "Study: continue Elementary series, note tactics",
-  "Light play: test new moves in quick game"
+  "Light play: test new moves in quick game",
+  "Read 1-dan challenge chapter",
+  "play piano",
+  "calisthenics workout",
+  "go for run"
 ];

--- a/wednesday.js
+++ b/wednesday.js
@@ -3,7 +3,9 @@ export default [
   "Study: continue Elementary series, note tactics",
   "Light play: test new moves in quick game",
   "Read 1-dan challenge chapter",
-  "play piano",
-  "calisthenics workout",
-  "go for run"
+  [
+    "play piano",
+    "calisthenics workout",
+    "go for run"
+  ]
 ];


### PR DESCRIPTION
## Summary
- append four universal tasks to each daily plan

## Testing
- `node -e "import('./monday.js').then(m=>console.log('ok'))"`
- `node -e "Promise.all([import('./tuesday.js'),import('./wednesday.js'),import('./thursday.js'),import('./friday.js'),import('./saturday.js'),import('./sunday.js')]).then(()=>console.log('all ok'))"`


------
https://chatgpt.com/codex/tasks/task_e_6887017e2470832b907094f4c17792ad