### PR TITLE
Reset tasks on new day

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ This project is a small web app that helps you keep track of daily workout objec
 3. Tick each objective as you complete it. Your progress and daily streak are saved automatically.
 4. The side panels show yesterday's and tomorrow's plans so you can prepare.
 5. A live countdown displays the time remaining until the next day.
+6. Checked tasks reset automatically when a new day begins.
 
 No server is required – everything runs entirely in the browser. The streak counter resets if you skip a day.
 

--- a/script.js
+++ b/script.js
@@ -165,8 +165,16 @@ function startCountdown() {
   const el = document.getElementById('countdown');
   if (!el) return;
 
+  let currentDay = dateStr(new Date());
+
   function update() {
     const now = new Date();
+    const todayStr = dateStr(now);
+    if (todayStr !== currentDay) {
+      location.reload();
+      return;
+    }
+
     const midnight = new Date();
     midnight.setHours(24, 0, 0, 0);
     let diff = midnight - now;


### PR DESCRIPTION
## Summary
- reload the page when the day rolls over so checkboxes reset
- document the automatic reset behaviour in the README

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_688793f9da28832bb1909e7c4401b885